### PR TITLE
Use apt-get instead of apt

### DIFF
--- a/cedar-infra-neo4j/Dockerfile
+++ b/cedar-infra-neo4j/Dockerfile
@@ -1,7 +1,7 @@
 FROM neo4j:5.3.0-community
 
-RUN apt update
-RUN apt -y install curl netcat
+RUN apt-get update
+RUN apt-get -y install curl netcat
 
 WORKDIR /var/lib/neo4j
 


### PR DESCRIPTION
I get this error with apt in Apple M1 when installing Cedar in an Ubuntu VM:

Step 1/14 : FROM neo4j:5.3.0-community
 ---> 97fc1c011e07
Step 2/14 : RUN apt update
 ---> Using cache
 ---> fb666fedaa8f
Step 3/14 : RUN apt -y install curl netcat
 ---> Running in 1e8388814068

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package curl
E: Unable to locate package netcat
The command '/bin/sh -c apt -y install curl netcat' returned a non-zero code: 100