### PR TITLE
Target Renovate updates at develop

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,9 @@
     "into a pull request. It does not decide anything - the version lock still says what may move,",
     "and the pairing check in CI still says what must move together."
   ],
+  "baseBranchPatterns": [
+    "develop"
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
Keeps the validated Renovate policy on the default branch while directing dependency pull requests to develop, where the full Docker CI and version-pairing gate run. Config-only; automerge remains disabled.